### PR TITLE
Add policy parameter to /token/generate requests

### DIFF
--- a/web-integrations/google-secure-signals/client-server/server.js
+++ b/web-integrations/google-secure-signals/client-server/server.js
@@ -124,7 +124,7 @@ function createEnvelope(payload) {
 }
 
 app.post('/login', async (req, res) => {
-  const jsonEmail = JSON.stringify({ email: req.body.email });
+  const jsonEmail = JSON.stringify({ email: req.body.email, policy: 1 });
   const { envelope, nonce } = createEnvelope(jsonEmail);
 
   const headers = {

--- a/web-integrations/google-secure-signals/server-side/server.js
+++ b/web-integrations/google-secure-signals/server-side/server.js
@@ -205,7 +205,7 @@ app.get('/getFreshToken', async (req, res) => {
 });
 
 app.post('/login', async (req, res) => {
-  const jsonEmail = JSON.stringify({ email: req.body.email });
+  const jsonEmail = JSON.stringify({ email: req.body.email, policy: 1 });
   const { envelope, nonce } = createEnvelope(jsonEmail);
 
   const headers = {

--- a/web-integrations/javascript-sdk/client-server/server.js
+++ b/web-integrations/javascript-sdk/client-server/server.js
@@ -113,7 +113,7 @@ function createEnvelope(payload) {
 }
 
 app.post('/login', async (req, res) => {
-    const jsonEmail = JSON.stringify({ 'email': req.body.email });
+    const jsonEmail = JSON.stringify({ 'email': req.body.email, 'policy': 1 });
     const { envelope, nonce } = createEnvelope(jsonEmail);
 
     const headers = {

--- a/web-integrations/prebid-integrations/client-server/server.js
+++ b/web-integrations/prebid-integrations/client-server/server.js
@@ -123,7 +123,7 @@ app.get('/', (req, res) => {
 
 // POST /login - Generates UID2/EUID token for email address
 app.post('/login', async (req, res) => {
-    const jsonEmail = JSON.stringify({ email: req.body.email });
+    const jsonEmail = JSON.stringify({ email: req.body.email, policy: 1 });
     const { envelope, nonce } = createEnvelope(jsonEmail);
 
     const headers = {

--- a/web-integrations/server-side/server.js
+++ b/web-integrations/server-side/server.js
@@ -177,7 +177,7 @@ app.get('/', async (req, res) => {
 });
 
 app.post('/login', async (req, res) => {
-  const jsonEmail = JSON.stringify({ 'email': req.body.email });
+  const jsonEmail = JSON.stringify({ 'email': req.body.email, 'policy': 1 });
   const { envelope, nonce } = createEnvelope(jsonEmail);
 
   const headers = {


### PR DESCRIPTION
Required for API clients created after Sept 1, 2023. Fixes error: 'Required opt-out policy argument for token/generate is missing or not set to 1'

Updated files:
- web-integrations/server-side/server.js
- web-integrations/javascript-sdk/client-server/server.js
- web-integrations/google-secure-signals/server-side/server.js
- web-integrations/google-secure-signals/client-server/server.js
- web-integrations/prebid-integrations/client-server/server.js