### PR TITLE
Rename docker images from uid2-* to uid-* 

### DIFF
--- a/.github/workflows/release-all-docker-images.yaml
+++ b/.github/workflows/release-all-docker-images.yaml
@@ -29,7 +29,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       docker_file: tools/reverse-proxy/Dockerfile
       docker_context: tools/reverse-proxy
-      docker_image_name: iabtechlab/uid2-reverse-proxy
+      docker_image_name: iabtechlab/uid-reverse-proxy
       docker_registry: ghcr.io
     secrets: inherit
 
@@ -42,7 +42,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       docker_file: web-integrations/google-secure-signals/client-server/Dockerfile
       docker_context: web-integrations/google-secure-signals/client-server
-      docker_image_name: iabtechlab/uid2-google-secure-signals-client-server
+      docker_image_name: iabtechlab/uid-google-secure-signals-client-server
       docker_registry: ghcr.io
     secrets: inherit
 
@@ -55,7 +55,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       docker_file: web-integrations/google-secure-signals/client-side/Dockerfile
       docker_context: web-integrations/google-secure-signals/client-side
-      docker_image_name: iabtechlab/uid2-google-secure-signals-client-side
+      docker_image_name: iabtechlab/uid-google-secure-signals-client-side
       docker_registry: ghcr.io
     secrets: inherit
 
@@ -68,7 +68,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       docker_file: web-integrations/google-secure-signals/server-side/Dockerfile
       docker_context: web-integrations/google-secure-signals/server-side
-      docker_image_name: iabtechlab/uid2-google-secure-signals-server-side
+      docker_image_name: iabtechlab/uid-google-secure-signals-server-side
       docker_registry: ghcr.io
     secrets: inherit
 
@@ -81,7 +81,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       docker_file: web-integrations/google-secure-signals/react-client-side/Dockerfile
       docker_context: web-integrations/google-secure-signals/react-client-side
-      docker_image_name: iabtechlab/uid2-google-secure-signals-react-client-side
+      docker_image_name: iabtechlab/uid-google-secure-signals-react-client-side
       docker_registry: ghcr.io
     secrets: inherit
 
@@ -94,7 +94,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       docker_file: web-integrations/javascript-sdk/client-side/Dockerfile
       docker_context: web-integrations/javascript-sdk/client-side
-      docker_image_name: iabtechlab/uid2-javascript-sdk-client-side
+      docker_image_name: iabtechlab/uid-javascript-sdk-client-side
       docker_registry: ghcr.io
     secrets: inherit
 
@@ -107,7 +107,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       docker_file: web-integrations/javascript-sdk/client-server/Dockerfile
       docker_context: web-integrations/javascript-sdk/client-server
-      docker_image_name: iabtechlab/uid2-javascript-sdk-client-server
+      docker_image_name: iabtechlab/uid-javascript-sdk-client-server
       docker_registry: ghcr.io
     secrets: inherit
 
@@ -120,7 +120,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       docker_file: web-integrations/javascript-sdk/react-client-side/Dockerfile
       docker_context: web-integrations/javascript-sdk/react-client-side
-      docker_image_name: iabtechlab/uid2-javascript-sdk-react-client-side
+      docker_image_name: iabtechlab/uid-javascript-sdk-react-client-side
       docker_registry: ghcr.io
     secrets: inherit
 
@@ -133,7 +133,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       docker_file: web-integrations/server-side/Dockerfile
       docker_context: web-integrations/server-side
-      docker_image_name: iabtechlab/uid2-server-side
+      docker_image_name: iabtechlab/uid-server-side
       docker_registry: ghcr.io
     secrets: inherit
 
@@ -146,7 +146,7 @@ jobs:
       release_type: ${{ inputs.release_type }}
       docker_file: web-integrations/prebid-integrations/client-side/Dockerfile
       docker_context: web-integrations/prebid-integrations
-      docker_image_name: iabtechlab/uid2-prebid-client-side
+      docker_image_name: iabtechlab/uid-prebid-client-side
       docker_registry: ghcr.io
     secrets: inherit
 
@@ -159,7 +159,20 @@ jobs:
       release_type: ${{ inputs.release_type }}
       docker_file: web-integrations/prebid-integrations/client-server/Dockerfile
       docker_context: web-integrations/prebid-integrations
-      docker_image_name: iabtechlab/uid2-prebid-client-server
+      docker_image_name: iabtechlab/uid-prebid-client-server
+      docker_registry: ghcr.io
+    secrets: inherit
+
+  publishPrebidClientSideDeferredImage:
+    uses: iabtechlab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@v3
+    needs: incrementVersionNumber
+    with: 
+      new_version: ${{ needs.incrementVersionNumber.outputs.new_version }}
+      image_tag: ${{ needs.incrementVersionNumber.outputs.image_tag }}
+      release_type: ${{ inputs.release_type }}
+      docker_file: web-integrations/prebid-integrations/client-side-deferred/Dockerfile
+      docker_context: web-integrations/prebid-integrations
+      docker_image_name: iabtechlab/uid-prebid-client-side-deferred
       docker_registry: ghcr.io
     secrets: inherit
 
@@ -172,6 +185,19 @@ jobs:
       release_type: ${{ inputs.release_type }}
       docker_file: web-integrations/prebid-secure-signals/client-side/Dockerfile
       docker_context: web-integrations/prebid-secure-signals
-      docker_image_name: iabtechlab/uid2-prebid-secure-signals-client-side
+      docker_image_name: iabtechlab/uid-prebid-secure-signals-client-side
+      docker_registry: ghcr.io
+    secrets: inherit
+
+  publishHashingToolImage:
+    uses: iabtechlab/uid2-shared-actions/.github/workflows/shared-publish-to-docker-versioned.yaml@v3
+    needs: incrementVersionNumber
+    with: 
+      new_version: ${{ needs.incrementVersionNumber.outputs.new_version }}
+      image_tag: ${{ needs.incrementVersionNumber.outputs.image_tag }}
+      release_type: ${{ inputs.release_type }}
+      docker_file: tools/hashing-tool/Dockerfile
+      docker_context: tools/hashing-tool
+      docker_image_name: iabtechlab/uid-hashing-tool
       docker_registry: ghcr.io
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uid2-examples",
-  "version": "0.2.89",
+  "version": "0.1.0",
   "private": true,
   "description": "UID2 Integration Examples",
   "license": "BSD-2-Clause",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uid2-examples",
-  "version": "0.1.0",
+  "version": "0.2.99",
   "private": true,
   "description": "UID2 Integration Examples",
   "license": "BSD-2-Clause",


### PR DESCRIPTION
Additional changes:
- Added two new images for prebid-deferred and hashing tool
- Reset version number to 0.1.0 since we have new image names

This a two part process, I have to merge and release these new images so they exist first before updating uid2-deployments