### PR TITLE
minimal log format to avoid logging bearer tokens/any sensitive headers

### DIFF
--- a/tools/reverse-proxy/nginx.conf
+++ b/tools/reverse-proxy/nginx.conf
@@ -12,21 +12,11 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                      '$status $body_bytes_sent "$http_referer" '
-                      '"$http_user_agent" "$http_x_forwarded_for"';
+    # Minimal log format to avoid logging sensitive headers (e.g., Authorization tokens)
+    # Only logs request URI, status code, and remote address
+    log_format  path_status  '$request_uri $status $remote_addr';
 
-    # Debug log format - shows Host header details for troubleshooting routing issues
-    log_format  debug_routing  '$remote_addr [$time_local] "$request" '
-                               'status=$status '
-                               'host="$host" '
-                               'http_host="$http_host" '
-                               'server_name="$server_name" '
-                               'scheme=$scheme '
-                               'x_forwarded_host="$http_x_forwarded_host" '
-                               'x_forwarded_proto="$http_x_forwarded_proto"';
-
-    access_log  /var/log/nginx/access.log  debug_routing;
+    access_log  /var/log/nginx/access.log  path_status;
 
     sendfile        on;
     #tcp_nopush     on;

--- a/tools/reverse-proxy/nginx.conf
+++ b/tools/reverse-proxy/nginx.conf
@@ -12,7 +12,6 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    # Minimal log format to avoid logging sensitive headers (e.g., Authorization tokens)
     log_format  path_status  '$remote_addr - $remote_user [$time_local] $request $status';
 
     # Debug log format - shows Host header details for troubleshooting routing issues

--- a/tools/reverse-proxy/nginx.conf
+++ b/tools/reverse-proxy/nginx.conf
@@ -13,8 +13,18 @@ http {
     default_type  application/octet-stream;
 
     # Minimal log format to avoid logging sensitive headers (e.g., Authorization tokens)
-    # Only logs request URI, status code, and remote address
-    log_format  path_status  '$request_uri $status $remote_addr';
+    log_format  path_status  '$remote_addr - $remote_user [$time_local] $request $status';
+
+    # Debug log format - shows Host header details for troubleshooting routing issues
+    # To use, switch access_log below to use debug_routing instead of path_status
+    log_format  debug_routing  '$remote_addr [$time_local] "$request" '
+                               'status=$status '
+                               'host="$host" '
+                               'http_host="$http_host" '
+                               'server_name="$server_name" '
+                               'scheme=$scheme '
+                               'x_forwarded_host="$http_x_forwarded_host" '
+                               'x_forwarded_proto="$http_x_forwarded_proto"';
 
     access_log  /var/log/nginx/access.log  path_status;
 


### PR DESCRIPTION
Log format matches the log format that was added in the web integrations PR to fix it in the old sample sites here: https://github.com/IABTechLab/uid2-web-integrations/blob/4ce26f0d4cd100a77e257858c5274e95ee7c7fdb/examples/cstg/nginx/nginx.conf#L21
