### PR TITLE
Fix Google Secure Signals UI detection for client-server and server-side

### DIFF
--- a/web-integrations/google-secure-signals/client-server/server.js
+++ b/web-integrations/google-secure-signals/client-server/server.js
@@ -19,7 +19,6 @@ const uidJsSdkName = process.env.UID_JS_SDK_NAME || '__uid2';
 
 // Secure Signals configuration
 const secureSignalsSdkUrl = process.env.UID_SECURE_SIGNALS_SDK_URL || 'https://cdn.integ.uidapi.com/uid2SecureSignal.js';
-// Fallback so the template always gets the correct localStorage key (matches what the SDK uses).
 const secureSignalsStorageKey = process.env.UID_SECURE_SIGNALS_STORAGE_KEY || '_GESPSK-uidapi.com';
 
 // UI/Display configuration

--- a/web-integrations/google-secure-signals/client-server/server.js
+++ b/web-integrations/google-secure-signals/client-server/server.js
@@ -19,6 +19,7 @@ const uidJsSdkName = process.env.UID_JS_SDK_NAME || '__uid2';
 
 // Secure Signals configuration
 const secureSignalsSdkUrl = process.env.UID_SECURE_SIGNALS_SDK_URL || 'https://cdn.integ.uidapi.com/uid2SecureSignal.js';
+// Fallback so the template always gets the correct localStorage key (matches what the SDK uses).
 const secureSignalsStorageKey = process.env.UID_SECURE_SIGNALS_STORAGE_KEY || '_GESPSK-uidapi.com';
 
 // UI/Display configuration

--- a/web-integrations/google-secure-signals/client-server/server.js
+++ b/web-integrations/google-secure-signals/client-server/server.js
@@ -19,6 +19,7 @@ const uidJsSdkName = process.env.UID_JS_SDK_NAME || '__uid2';
 
 // Secure Signals configuration
 const secureSignalsSdkUrl = process.env.UID_SECURE_SIGNALS_SDK_URL || 'https://cdn.integ.uidapi.com/uid2SecureSignal.js';
+const secureSignalsStorageKey = process.env.UID_SECURE_SIGNALS_STORAGE_KEY || '_GESPSK-uidapi.com';
 
 // UI/Display configuration
 const identityName = process.env.IDENTITY_NAME;
@@ -48,7 +49,7 @@ app.get('/', (req, res) => {
     uidJsSdkUrl,
     uidJsSdkName,
     secureSignalsSdkUrl,
-    secureSignalsStorageKey: process.env.UID_SECURE_SIGNALS_STORAGE_KEY,
+    secureSignalsStorageKey,
     identityName,
     docsBaseUrl
   });
@@ -147,7 +148,7 @@ app.post('/login', async (req, res) => {
         uidJsSdkUrl,
         uidJsSdkName,
         secureSignalsSdkUrl,
-        secureSignalsStorageKey: process.env.UID_SECURE_SIGNALS_STORAGE_KEY,
+        secureSignalsStorageKey,
         identityName,
         docsBaseUrl
       });
@@ -173,7 +174,7 @@ app.post('/login', async (req, res) => {
         uidJsSdkUrl,
         uidJsSdkName,
         secureSignalsSdkUrl,
-        secureSignalsStorageKey: process.env.UID_SECURE_SIGNALS_STORAGE_KEY,
+        secureSignalsStorageKey,
         identityName,
         docsBaseUrl
       });

--- a/web-integrations/google-secure-signals/client-server/views/index.html
+++ b/web-integrations/google-secure-signals/client-server/views/index.html
@@ -25,8 +25,10 @@
           $("#login_required").html(sdk.isLoginRequired() ? "yes" : "no");
           $("#identity_state").html(String(JSON.stringify(payload, null, 2)));
           
-          // Update Secure Signals values displayed in the GUI
           updateSecureSignals();
+          if (sdk.getAdvertisingToken()) {
+            setTimeout(updateSecureSignals, 1000);
+          }
 
           <% if (isOptout) { %>
           $("#login_form").hide();
@@ -35,7 +37,6 @@
           $("#optout_banner").show();
           $('#googleAdContainer').hide();
           <% } else { %>
-          // before token generation, show login form
           if (sdk.isLoginRequired()) {
             $("#login_form").show();
             $("#logout_form").hide();
@@ -43,7 +44,6 @@
             $("#optout_banner").hide();
             $('#googleAdContainer').hide();
           } else {
-            // Success case - token generated, show logout form
             $("#login_form").hide();
             $("#logout_form").show();
             $("#optout_form").hide();
@@ -55,12 +55,14 @@
         
         function updateSecureSignals() {
           try {
-            // Read from localStorage 
             const secureSignalsStorageKey = '<%- secureSignalsStorageKey %>';
             const secureSignalsStorage = localStorage[secureSignalsStorageKey];
-            
+            const token = sdk.getAdvertisingToken();
+            if (token && !secureSignalsStorage) {
+              location.reload();
+              return;
+            }
             const secureSignalsStorageJson = secureSignalsStorage && JSON.parse(secureSignalsStorage);
-            
             if (secureSignalsStorageJson && secureSignalsStorageJson[1]) {
               $("#secure_signals_loaded").html("yes");
               $("#secure_signals_value").html(JSON.stringify(secureSignalsStorageJson, null, 2));
@@ -83,12 +85,14 @@
         $("#logout").click(() => {
           window.googletag.secureSignalProviders.clearAllCache();
           sdk.disconnect();
+          localStorage.removeItem('<%- secureSignalsStorageKey %>');
           window.location.href = '/';
         });
         
         $("#try_another").click(() => {
           window.googletag.secureSignalProviders.clearAllCache();
           sdk.disconnect();
+          localStorage.removeItem('<%- secureSignalsStorageKey %>');
           window.location.href = '/';
         });
 
@@ -103,16 +107,12 @@
         sdk.callbacks.push((eventType, payload) => {
           if (eventType === 'InitCompleted') {
             <% if (identity !== null && typeof identity !== 'undefined') { %>
-            // Server provided an identity, set it
             if (sdk.isLoginRequired()) {
               sdk.setIdentity(<%- JSON.stringify(identity) %>);
             } else {
-              // Identity already exists, just update GUI
               updateGuiElements(payload);
             }
             <% } else { %>
-            // No identity from server (including opt-out case)
-            // SDK will naturally remain in "login required" state
             updateGuiElements(payload);
             <% if (isOptout) { %>
             $("#optout_banner").show();
@@ -160,6 +160,7 @@
 
         <!-- UID2 Integration Status Section -->
         <h2><%- identityName %> Integration Status</h2>
+        <p class="section-summary"><strong>Note:</strong> This is a test-only integration environment—it does not collect data or generate production-level tokens.</p>
 
         <table id="uid_state">
           <tr>
@@ -237,7 +238,7 @@
                 </div>
               </div>
             </td>
-            <td class="value"><pre id="secure_signals_loaded"></pre></td>
+            <td class="value"><pre id="secure_signals_loaded">no</pre></td>
           </tr>
           <tr>
             <td class="label">
@@ -251,7 +252,7 @@
                 </div>
               </div>
             </td>
-            <td class="value"><pre id="secure_signals_value"></pre></td>
+            <td class="value"><pre id="secure_signals_value">undefined</pre></td>
           </tr>
         </table>
 

--- a/web-integrations/google-secure-signals/client-server/views/index.html
+++ b/web-integrations/google-secure-signals/client-server/views/index.html
@@ -6,126 +6,6 @@
     <link rel="stylesheet" type="text/css" href="/stylesheets/app.css" />
     <link rel="stylesheet" type="text/css" href="/stylesheets/style.css" />
     <link rel="shortcut icon" href="/images/favicon.png" />
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="<%- uidJsSdkUrl %>"></script>
-    <script src="<%- secureSignalsSdkUrl %>"></script>
-    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
-
-    <script>
-      $(document).ready(() => {
-        const sdkName = '<%- uidJsSdkName %>';
-        let sdk = window[sdkName];
-        sdk = sdk || { callbacks: [] };
-        
-        function updateGuiElements(payload) {
-          $("#targeted_advertising_ready").html(
-            sdk.getAdvertisingToken() ? "yes" : "no"
-          );
-          $("#advertising_token").html(String(sdk.getAdvertisingToken()));
-          $("#login_required").html(sdk.isLoginRequired() ? "yes" : "no");
-          $("#identity_state").html(String(JSON.stringify(payload, null, 2)));
-          
-          updateSecureSignals();
-          // Give Secure Signals SDK time to write to localStorage; run again after 1s when we have a token.
-          if (sdk.getAdvertisingToken()) {
-            setTimeout(updateSecureSignals, 1000);
-          }
-
-          <% if (isOptout) { %>
-          $("#login_form").hide();
-          $("#logout_form").hide();
-          $("#optout_form").show();
-          $("#optout_banner").show();
-          $('#googleAdContainer').hide();
-          <% } else { %>
-          if (sdk.isLoginRequired()) {
-            $("#login_form").show();
-            $("#logout_form").hide();
-            $("#optout_form").hide();
-            $("#optout_banner").hide();
-            $('#googleAdContainer').hide();
-          } else {
-            $("#login_form").hide();
-            $("#logout_form").show();
-            $("#optout_form").hide();
-            $("#optout_banner").hide();
-            $('#googleAdContainer').show();
-          }
-          <% } %>
-        }
-        
-        function updateSecureSignals() {
-          try {
-            const secureSignalsStorageKey = '<%- secureSignalsStorageKey %>';
-            const secureSignalsStorage = localStorage[secureSignalsStorageKey];
-            const token = sdk.getAdvertisingToken();
-            // Token valid but Secure Signals not yet written; reload so the SDK gets another chance.
-            if (token && !secureSignalsStorage) {
-              location.reload();
-              return;
-            }
-            const secureSignalsStorageJson = secureSignalsStorage && JSON.parse(secureSignalsStorage);
-            if (secureSignalsStorageJson && secureSignalsStorageJson[1]) {
-              $("#secure_signals_loaded").html("yes");
-              $("#secure_signals_value").html(JSON.stringify(secureSignalsStorageJson, null, 2));
-            } else {
-              $("#secure_signals_loaded").html("no");
-              $("#secure_signals_value").html("undefined");
-            }
-          } catch (e) {
-            console.log("Secure signals not yet available", e);
-            $("#secure_signals_loaded").html("no");
-            $("#secure_signals_value").html("undefined");
-          }
-        }
-
-        function onIdentityUpdated(eventType, payload) {
-          // Allow secure signals time to load
-          setTimeout(() => updateGuiElements(payload), 1000);
-        }
-
-        $("#logout").click(() => {
-          window.googletag.secureSignalProviders.clearAllCache();
-          sdk.disconnect();
-          localStorage.removeItem('<%- secureSignalsStorageKey %>');
-          window.location.href = '/';
-        });
-        
-        $("#try_another").click(() => {
-          window.googletag.secureSignalProviders.clearAllCache();
-          sdk.disconnect();
-          localStorage.removeItem('<%- secureSignalsStorageKey %>');
-          window.location.href = '/';
-        });
-
-        sdk.callbacks.push((eventType, payload) => {
-          if (eventType === "SdkLoaded") {
-            sdk.init({
-              baseUrl: "<%- uidBaseUrl %>",
-            });
-          }
-        });
-        
-        sdk.callbacks.push((eventType, payload) => {
-          if (eventType === 'InitCompleted') {
-            <% if (identity !== null && typeof identity !== 'undefined') { %>
-            if (sdk.isLoginRequired()) {
-              sdk.setIdentity(<%- JSON.stringify(identity) %>);
-            } else {
-              updateGuiElements(payload);
-            }
-            <% } else { %>
-            updateGuiElements(payload);
-            <% if (isOptout) { %>
-            $("#optout_banner").show();
-            <% } %>
-            <% } %>
-          }
-        });
-        
-        sdk.callbacks.push(onIdentityUpdated);
-      });
-    </script>
   </head>
   <body>
     <div class="page-wrapper">
@@ -331,5 +211,125 @@
         </div>
       </aside>
     </div>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="<%- uidJsSdkUrl %>"></script>
+    <script src="<%- secureSignalsSdkUrl %>"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+    <script>
+      $(document).ready(() => {
+        const sdkName = '<%- uidJsSdkName %>';
+        let sdk = window[sdkName];
+        sdk = sdk || { callbacks: [] };
+        
+        function updateGuiElements(payload) {
+          $("#targeted_advertising_ready").html(
+            sdk.getAdvertisingToken() ? "yes" : "no"
+          );
+          $("#advertising_token").html(String(sdk.getAdvertisingToken()));
+          $("#login_required").html(sdk.isLoginRequired() ? "yes" : "no");
+          $("#identity_state").html(String(JSON.stringify(payload, null, 2)));
+          
+          updateSecureSignals();
+          // Token is set from the server (or refreshed by the SDK); Secure Signals may write to localStorage after a short delay, so re-check once.
+          if (sdk.getAdvertisingToken()) {
+            setTimeout(updateSecureSignals, 1000);
+          }
+
+          <% if (isOptout) { %>
+          $("#login_form").hide();
+          $("#logout_form").hide();
+          $("#optout_form").show();
+          $("#optout_banner").show();
+          $('#googleAdContainer').hide();
+          <% } else { %>
+          if (sdk.isLoginRequired()) {
+            $("#login_form").show();
+            $("#logout_form").hide();
+            $("#optout_form").hide();
+            $("#optout_banner").hide();
+            $('#googleAdContainer').hide();
+          } else {
+            $("#login_form").hide();
+            $("#logout_form").show();
+            $("#optout_form").hide();
+            $("#optout_banner").hide();
+            $('#googleAdContainer').show();
+          }
+          <% } %>
+        }
+        
+        // Update Secure Signals values displayed in the GUI.
+        function updateSecureSignals() {
+          try {
+            const secureSignalsStorageKey = '<%- secureSignalsStorageKey %>';
+            const secureSignalsStorage = localStorage[secureSignalsStorageKey];
+            const token = sdk.getAdvertisingToken();
+            // Token valid but Secure Signals not yet written; reload so the SDK gets another chance.
+            if (token && !secureSignalsStorage) {
+              location.reload();
+              return;
+            }
+            const secureSignalsStorageJson = secureSignalsStorage && JSON.parse(secureSignalsStorage);
+            if (secureSignalsStorageJson && secureSignalsStorageJson[1]) {
+              $("#secure_signals_loaded").html("yes");
+              $("#secure_signals_value").html(JSON.stringify(secureSignalsStorageJson, null, 2));
+            } else {
+              $("#secure_signals_loaded").html("no");
+              $("#secure_signals_value").html("undefined");
+            }
+          } catch (e) {
+            console.log("Secure signals not yet available", e);
+            $("#secure_signals_loaded").html("no");
+            $("#secure_signals_value").html("undefined");
+          }
+        }
+
+        function onIdentityUpdated(eventType, payload) {
+          // Allow secure signals time to load
+          setTimeout(() => updateGuiElements(payload), 1000);
+        }
+
+        $("#logout").click(() => {
+          window.googletag.secureSignalProviders.clearAllCache();
+          sdk.disconnect();
+          localStorage.removeItem('<%- secureSignalsStorageKey %>');
+          window.location.href = '/';
+        });
+        
+        $("#try_another").click(() => {
+          window.googletag.secureSignalProviders.clearAllCache();
+          sdk.disconnect();
+          localStorage.removeItem('<%- secureSignalsStorageKey %>');
+          window.location.href = '/';
+        });
+
+        sdk.callbacks.push((eventType, payload) => {
+          if (eventType === "SdkLoaded") {
+            sdk.init({
+              baseUrl: "<%- uidBaseUrl %>",
+            });
+          }
+        });
+        
+        sdk.callbacks.push((eventType, payload) => {
+          if (eventType === 'InitCompleted') {
+            <% if (identity !== null && typeof identity !== 'undefined') { %>
+            if (sdk.isLoginRequired()) {
+              sdk.setIdentity(<%- JSON.stringify(identity) %>);
+            } else {
+              updateGuiElements(payload);
+            }
+            <% } else { %>
+            updateGuiElements(payload);
+            <% if (isOptout) { %>
+            $("#optout_banner").show();
+            <% } %>
+            <% } %>
+          }
+        });
+        
+        sdk.callbacks.push(onIdentityUpdated);
+      });
+    </script>
   </body>
 </html>

--- a/web-integrations/google-secure-signals/client-server/views/index.html
+++ b/web-integrations/google-secure-signals/client-server/views/index.html
@@ -26,6 +26,7 @@
           $("#identity_state").html(String(JSON.stringify(payload, null, 2)));
           
           updateSecureSignals();
+          // Give Secure Signals SDK time to write to localStorage; run again after 1s when we have a token.
           if (sdk.getAdvertisingToken()) {
             setTimeout(updateSecureSignals, 1000);
           }
@@ -58,6 +59,7 @@
             const secureSignalsStorageKey = '<%- secureSignalsStorageKey %>';
             const secureSignalsStorage = localStorage[secureSignalsStorageKey];
             const token = sdk.getAdvertisingToken();
+            // Token valid but Secure Signals not yet written; reload so the SDK gets another chance.
             if (token && !secureSignalsStorage) {
               location.reload();
               return;

--- a/web-integrations/google-secure-signals/client-server/views/index.html
+++ b/web-integrations/google-secure-signals/client-server/views/index.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" type="text/css" href="/stylesheets/app.css" />
     <link rel="stylesheet" type="text/css" href="/stylesheets/style.css" />
     <link rel="shortcut icon" href="/images/favicon.png" />
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="<%- uidJsSdkUrl %>"></script>
     <script src="<%- secureSignalsSdkUrl %>"></script>
@@ -23,7 +24,6 @@
           $("#advertising_token").html(String(sdk.getAdvertisingToken()));
           $("#login_required").html(sdk.isLoginRequired() ? "yes" : "no");
           $("#identity_state").html(String(JSON.stringify(payload, null, 2)));
-          
           updateSecureSignals();
           // Token is set from the server (or refreshed by the SDK); Secure Signals may write to localStorage after a short delay, so re-check once.
           if (sdk.getAdvertisingToken()) {
@@ -37,6 +37,7 @@
           $("#optout_banner").show();
           $('#googleAdContainer').hide();
           <% } else { %>
+          // Before token generation, show login form.
           if (sdk.isLoginRequired()) {
             $("#login_form").show();
             $("#logout_form").hide();
@@ -44,6 +45,7 @@
             $("#optout_banner").hide();
             $('#googleAdContainer').hide();
           } else {
+            // Success case - token generated, show logout form.
             $("#login_form").hide();
             $("#logout_form").show();
             $("#optout_form").hide();
@@ -54,9 +56,11 @@
         }
         
         // Update Secure Signals values displayed in the GUI.
+        // Update Secure Signals values displayed in the GUI.
         function updateSecureSignals() {
           try {
             const secureSignalsStorageKey = '<%- secureSignalsStorageKey %>';
+            // Read from localStorage.
             const secureSignalsStorage = localStorage[secureSignalsStorageKey];
             const token = sdk.getAdvertisingToken();
             // Token valid but Secure Signals not yet written; reload so the SDK gets another chance.
@@ -64,6 +68,7 @@
               location.reload();
               return;
             }
+
             const secureSignalsStorageJson = secureSignalsStorage && JSON.parse(secureSignalsStorage);
             if (secureSignalsStorageJson && secureSignalsStorageJson[1]) {
               $("#secure_signals_loaded").html("yes");

--- a/web-integrations/google-secure-signals/client-server/views/index.html
+++ b/web-integrations/google-secure-signals/client-server/views/index.html
@@ -6,6 +6,127 @@
     <link rel="stylesheet" type="text/css" href="/stylesheets/app.css" />
     <link rel="stylesheet" type="text/css" href="/stylesheets/style.css" />
     <link rel="shortcut icon" href="/images/favicon.png" />
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="<%- uidJsSdkUrl %>"></script>
+    <script src="<%- secureSignalsSdkUrl %>"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+    <script>
+      $(document).ready(() => {
+        const sdkName = '<%- uidJsSdkName %>';
+        let sdk = window[sdkName];
+        sdk = sdk || { callbacks: [] };
+        
+        function updateGuiElements(payload) {
+          $("#targeted_advertising_ready").html(
+            sdk.getAdvertisingToken() ? "yes" : "no"
+          );
+          $("#advertising_token").html(String(sdk.getAdvertisingToken()));
+          $("#login_required").html(sdk.isLoginRequired() ? "yes" : "no");
+          $("#identity_state").html(String(JSON.stringify(payload, null, 2)));
+          
+          updateSecureSignals();
+          // Token is set from the server (or refreshed by the SDK); Secure Signals may write to localStorage after a short delay, so re-check once.
+          if (sdk.getAdvertisingToken()) {
+            setTimeout(updateSecureSignals, 1000);
+          }
+
+          <% if (isOptout) { %>
+          $("#login_form").hide();
+          $("#logout_form").hide();
+          $("#optout_form").show();
+          $("#optout_banner").show();
+          $('#googleAdContainer').hide();
+          <% } else { %>
+          if (sdk.isLoginRequired()) {
+            $("#login_form").show();
+            $("#logout_form").hide();
+            $("#optout_form").hide();
+            $("#optout_banner").hide();
+            $('#googleAdContainer').hide();
+          } else {
+            $("#login_form").hide();
+            $("#logout_form").show();
+            $("#optout_form").hide();
+            $("#optout_banner").hide();
+            $('#googleAdContainer').show();
+          }
+          <% } %>
+        }
+        
+        // Update Secure Signals values displayed in the GUI.
+        function updateSecureSignals() {
+          try {
+            const secureSignalsStorageKey = '<%- secureSignalsStorageKey %>';
+            const secureSignalsStorage = localStorage[secureSignalsStorageKey];
+            const token = sdk.getAdvertisingToken();
+            // Token valid but Secure Signals not yet written; reload so the SDK gets another chance.
+            if (token && !secureSignalsStorage) {
+              location.reload();
+              return;
+            }
+            const secureSignalsStorageJson = secureSignalsStorage && JSON.parse(secureSignalsStorage);
+            if (secureSignalsStorageJson && secureSignalsStorageJson[1]) {
+              $("#secure_signals_loaded").html("yes");
+              $("#secure_signals_value").html(JSON.stringify(secureSignalsStorageJson, null, 2));
+            } else {
+              $("#secure_signals_loaded").html("no");
+              $("#secure_signals_value").html("undefined");
+            }
+          } catch (e) {
+            console.log("Secure signals not yet available", e);
+            $("#secure_signals_loaded").html("no");
+            $("#secure_signals_value").html("undefined");
+          }
+        }
+
+        function onIdentityUpdated(eventType, payload) {
+          // Allow secure signals time to load
+          setTimeout(() => updateGuiElements(payload), 1000);
+        }
+
+        // Clear UID2: tell GPT to drop cached signals, disconnect the SDK, remove Secure Signals from localStorage, then redirect.
+        $("#logout").click(() => {
+          window.googletag.secureSignalProviders.clearAllCache();
+          sdk.disconnect();
+          localStorage.removeItem('<%- secureSignalsStorageKey %>');
+          window.location.href = '/';
+        });
+        // Try Another Email: same cleanup as Clear so the next login gets a fresh state.
+        $("#try_another").click(() => {
+          window.googletag.secureSignalProviders.clearAllCache();
+          sdk.disconnect();
+          localStorage.removeItem('<%- secureSignalsStorageKey %>');
+          window.location.href = '/';
+        });
+
+        sdk.callbacks.push((eventType, payload) => {
+          if (eventType === "SdkLoaded") {
+            sdk.init({
+              baseUrl: "<%- uidBaseUrl %>",
+            });
+          }
+        });
+        
+        sdk.callbacks.push((eventType, payload) => {
+          if (eventType === 'InitCompleted') {
+            <% if (identity !== null && typeof identity !== 'undefined') { %>
+            if (sdk.isLoginRequired()) {
+              sdk.setIdentity(<%- JSON.stringify(identity) %>);
+            } else {
+              updateGuiElements(payload);
+            }
+            <% } else { %>
+            updateGuiElements(payload);
+            <% if (isOptout) { %>
+            $("#optout_banner").show();
+            <% } %>
+            <% } %>
+          }
+        });
+        
+        sdk.callbacks.push(onIdentityUpdated);
+      });
+    </script>
   </head>
   <body>
     <div class="page-wrapper">
@@ -211,125 +332,5 @@
         </div>
       </aside>
     </div>
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="<%- uidJsSdkUrl %>"></script>
-    <script src="<%- secureSignalsSdkUrl %>"></script>
-    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
-    <script>
-      $(document).ready(() => {
-        const sdkName = '<%- uidJsSdkName %>';
-        let sdk = window[sdkName];
-        sdk = sdk || { callbacks: [] };
-        
-        function updateGuiElements(payload) {
-          $("#targeted_advertising_ready").html(
-            sdk.getAdvertisingToken() ? "yes" : "no"
-          );
-          $("#advertising_token").html(String(sdk.getAdvertisingToken()));
-          $("#login_required").html(sdk.isLoginRequired() ? "yes" : "no");
-          $("#identity_state").html(String(JSON.stringify(payload, null, 2)));
-          
-          updateSecureSignals();
-          // Token is set from the server (or refreshed by the SDK); Secure Signals may write to localStorage after a short delay, so re-check once.
-          if (sdk.getAdvertisingToken()) {
-            setTimeout(updateSecureSignals, 1000);
-          }
-
-          <% if (isOptout) { %>
-          $("#login_form").hide();
-          $("#logout_form").hide();
-          $("#optout_form").show();
-          $("#optout_banner").show();
-          $('#googleAdContainer').hide();
-          <% } else { %>
-          if (sdk.isLoginRequired()) {
-            $("#login_form").show();
-            $("#logout_form").hide();
-            $("#optout_form").hide();
-            $("#optout_banner").hide();
-            $('#googleAdContainer').hide();
-          } else {
-            $("#login_form").hide();
-            $("#logout_form").show();
-            $("#optout_form").hide();
-            $("#optout_banner").hide();
-            $('#googleAdContainer').show();
-          }
-          <% } %>
-        }
-        
-        // Update Secure Signals values displayed in the GUI.
-        function updateSecureSignals() {
-          try {
-            const secureSignalsStorageKey = '<%- secureSignalsStorageKey %>';
-            const secureSignalsStorage = localStorage[secureSignalsStorageKey];
-            const token = sdk.getAdvertisingToken();
-            // Token valid but Secure Signals not yet written; reload so the SDK gets another chance.
-            if (token && !secureSignalsStorage) {
-              location.reload();
-              return;
-            }
-            const secureSignalsStorageJson = secureSignalsStorage && JSON.parse(secureSignalsStorage);
-            if (secureSignalsStorageJson && secureSignalsStorageJson[1]) {
-              $("#secure_signals_loaded").html("yes");
-              $("#secure_signals_value").html(JSON.stringify(secureSignalsStorageJson, null, 2));
-            } else {
-              $("#secure_signals_loaded").html("no");
-              $("#secure_signals_value").html("undefined");
-            }
-          } catch (e) {
-            console.log("Secure signals not yet available", e);
-            $("#secure_signals_loaded").html("no");
-            $("#secure_signals_value").html("undefined");
-          }
-        }
-
-        function onIdentityUpdated(eventType, payload) {
-          // Allow secure signals time to load
-          setTimeout(() => updateGuiElements(payload), 1000);
-        }
-
-        $("#logout").click(() => {
-          window.googletag.secureSignalProviders.clearAllCache();
-          sdk.disconnect();
-          localStorage.removeItem('<%- secureSignalsStorageKey %>');
-          window.location.href = '/';
-        });
-        
-        $("#try_another").click(() => {
-          window.googletag.secureSignalProviders.clearAllCache();
-          sdk.disconnect();
-          localStorage.removeItem('<%- secureSignalsStorageKey %>');
-          window.location.href = '/';
-        });
-
-        sdk.callbacks.push((eventType, payload) => {
-          if (eventType === "SdkLoaded") {
-            sdk.init({
-              baseUrl: "<%- uidBaseUrl %>",
-            });
-          }
-        });
-        
-        sdk.callbacks.push((eventType, payload) => {
-          if (eventType === 'InitCompleted') {
-            <% if (identity !== null && typeof identity !== 'undefined') { %>
-            if (sdk.isLoginRequired()) {
-              sdk.setIdentity(<%- JSON.stringify(identity) %>);
-            } else {
-              updateGuiElements(payload);
-            }
-            <% } else { %>
-            updateGuiElements(payload);
-            <% if (isOptout) { %>
-            $("#optout_banner").show();
-            <% } %>
-            <% } %>
-          }
-        });
-        
-        sdk.callbacks.push(onIdentityUpdated);
-      });
-    </script>
   </body>
 </html>

--- a/web-integrations/google-secure-signals/client-server/views/index.html
+++ b/web-integrations/google-secure-signals/client-server/views/index.html
@@ -11,6 +11,7 @@
     <script src="<%- uidJsSdkUrl %>"></script>
     <script src="<%- secureSignalsSdkUrl %>"></script>
     <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+    
     <script>
       $(document).ready(() => {
         const sdkName = '<%- uidJsSdkName %>';
@@ -24,8 +25,9 @@
           $("#advertising_token").html(String(sdk.getAdvertisingToken()));
           $("#login_required").html(sdk.isLoginRequired() ? "yes" : "no");
           $("#identity_state").html(String(JSON.stringify(payload, null, 2)));
+          
           updateSecureSignals();
-          // Token is set from the server (or refreshed by the SDK); Secure Signals may write to localStorage after a short delay, so re-check once.
+          // Secure Signals SDK usually writes to localStorage shortly after it gets the token.
           if (sdk.getAdvertisingToken()) {
             setTimeout(updateSecureSignals, 1000);
           }
@@ -37,7 +39,7 @@
           $("#optout_banner").show();
           $('#googleAdContainer').hide();
           <% } else { %>
-          // Before token generation, show login form.
+          // before token generation, show login form.
           if (sdk.isLoginRequired()) {
             $("#login_form").show();
             $("#logout_form").hide();
@@ -45,7 +47,7 @@
             $("#optout_banner").hide();
             $('#googleAdContainer').hide();
           } else {
-            // Success case - token generated, show logout form.
+            // Success case - token generated, show logout form
             $("#login_form").hide();
             $("#logout_form").show();
             $("#optout_form").hide();
@@ -55,12 +57,10 @@
           <% } %>
         }
         
-        // Update Secure Signals values displayed in the GUI.
-        // Update Secure Signals values displayed in the GUI.
         function updateSecureSignals() {
           try {
             const secureSignalsStorageKey = '<%- secureSignalsStorageKey %>';
-            // Read from localStorage.
+
             const secureSignalsStorage = localStorage[secureSignalsStorageKey];
             const token = sdk.getAdvertisingToken();
             // Token valid but Secure Signals not yet written; reload so the SDK gets another chance.
@@ -89,14 +89,12 @@
           setTimeout(() => updateGuiElements(payload), 1000);
         }
 
-        // Clear UID2: tell GPT to drop cached signals, disconnect the SDK, remove Secure Signals from localStorage, then redirect.
         $("#logout").click(() => {
           window.googletag.secureSignalProviders.clearAllCache();
           sdk.disconnect();
           localStorage.removeItem('<%- secureSignalsStorageKey %>');
           window.location.href = '/';
         });
-        // Try Another Email: same cleanup as Clear so the next login gets a fresh state.
         $("#try_another").click(() => {
           window.googletag.secureSignalProviders.clearAllCache();
           sdk.disconnect();
@@ -104,7 +102,7 @@
           window.location.href = '/';
         });
 
-        sdk.callbacks.push((eventType, payload) => {
+        sdk.callbacks.push((eventType, payload) => {         
           if (eventType === "SdkLoaded") {
             sdk.init({
               baseUrl: "<%- uidBaseUrl %>",
@@ -115,12 +113,16 @@
         sdk.callbacks.push((eventType, payload) => {
           if (eventType === 'InitCompleted') {
             <% if (identity !== null && typeof identity !== 'undefined') { %>
-            if (sdk.isLoginRequired()) {
+              // If identity is set, set it on the SDK
+              if (sdk.isLoginRequired()) {
               sdk.setIdentity(<%- JSON.stringify(identity) %>);
             } else {
+              // Identity already exists, just update GUI
               updateGuiElements(payload);
             }
             <% } else { %>
+            // No identity from server (including opt-out case)
+            // SDK will naturally remain in "login required" state
             updateGuiElements(payload);
             <% if (isOptout) { %>
             $("#optout_banner").show();

--- a/web-integrations/google-secure-signals/client-server/views/index.html
+++ b/web-integrations/google-secure-signals/client-server/views/index.html
@@ -102,7 +102,7 @@
           window.location.href = '/';
         });
 
-        sdk.callbacks.push((eventType, payload) => {         
+        sdk.callbacks.push((eventType, payload) => {     
           if (eventType === "SdkLoaded") {
             sdk.init({
               baseUrl: "<%- uidBaseUrl %>",
@@ -113,8 +113,8 @@
         sdk.callbacks.push((eventType, payload) => {
           if (eventType === 'InitCompleted') {
             <% if (identity !== null && typeof identity !== 'undefined') { %>
-              // If identity is set, set it on the SDK
-              if (sdk.isLoginRequired()) {
+            // Server provided an identity, set it
+            if (sdk.isLoginRequired()) {
               sdk.setIdentity(<%- JSON.stringify(identity) %>);
             } else {
               // Identity already exists, just update GUI

--- a/web-integrations/google-secure-signals/server-side/server.js
+++ b/web-integrations/google-secure-signals/server-side/server.js
@@ -16,7 +16,6 @@ const uidClientSecret = process.env.UID_CLIENT_SECRET;
 
 // Secure Signals configuration
 const secureSignalsSdkUrl = process.env.UID_SECURE_SIGNALS_SDK_URL || 'https://cdn.integ.uidapi.com/uid2SecureSignal.js';
-// Fallback so the template always gets the correct localStorage key (matches what the SDK uses).
 const secureSignalsStorageKey = process.env.UID_SECURE_SIGNALS_STORAGE_KEY || '_GESPSK-uidapi.com';
 
 // UI/Display configuration

--- a/web-integrations/google-secure-signals/server-side/server.js
+++ b/web-integrations/google-secure-signals/server-side/server.js
@@ -16,6 +16,7 @@ const uidClientSecret = process.env.UID_CLIENT_SECRET;
 
 // Secure Signals configuration
 const secureSignalsSdkUrl = process.env.UID_SECURE_SIGNALS_SDK_URL || 'https://cdn.integ.uidapi.com/uid2SecureSignal.js';
+// Fallback so the template always gets the correct localStorage key (matches what the SDK uses).
 const secureSignalsStorageKey = process.env.UID_SECURE_SIGNALS_STORAGE_KEY || '_GESPSK-uidapi.com';
 
 // UI/Display configuration

--- a/web-integrations/google-secure-signals/server-side/views/index.html
+++ b/web-integrations/google-secure-signals/server-side/views/index.html
@@ -47,7 +47,7 @@
           }
         }
         
-        // No "token ready" event on server-side; poll so we update the UI after the SDK writes to localStorage.
+        // Update Secure Signals display after SDK has time to load and fetch token, allowing for additional tries
         [1000, 2000, 3000].forEach((ms) => setTimeout(updateSecureSignals, ms));
         
         $('#logout').click(() => {

--- a/web-integrations/google-secure-signals/server-side/views/index.html
+++ b/web-integrations/google-secure-signals/server-side/views/index.html
@@ -6,68 +6,6 @@
     <link rel="stylesheet" type="text/css" href="/stylesheets/app.css" />
     <link rel="stylesheet" type="text/css" href="/stylesheets/style.css" />
     <link rel="shortcut icon" href="/images/favicon.png" />
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script type="text/javascript">
-      // Define callback before Secure Signals SDK loads so the SDK can find it when it runs.
-      const getUid2AdvertisingToken = async () => {
-        const response = await fetch('/getFreshToken');
-        if (!response.ok) return undefined;
-        const result = await response.json();
-        return result && result.advertising_token;
-      };
-      window.getUid2AdvertisingToken = getUid2AdvertisingToken;
-    </script>
-    <!-- Load Secure Signals SDK after callback (sync, same order as client-side). -->
-    <script src="<%- secureSignalsSdkUrl %>"></script>
-    <script type="text/javascript">
-      if (window.__uid2SecureSignalProvider) {
-        window.__uid2SecureSignalProvider.registerSecureSignalProvider();
-      }
-    </script>
-    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
-    <script>
-      $(document).ready(() => {
-        const secureSignalsStorageKey = '<%- secureSignalsStorageKey %>';
-        
-        function updateSecureSignals() {
-          try {
-            const secureSignalsStorage = localStorage[secureSignalsStorageKey];
-            const secureSignalsStorageJson = secureSignalsStorage && JSON.parse(secureSignalsStorage);
-            
-            if (secureSignalsStorageJson && secureSignalsStorageJson[1]) {
-              $("#secure_signals_loaded").html("yes");
-              $("#secure_signals_value").html(JSON.stringify(secureSignalsStorageJson, null, 2));
-            } else {
-              $("#secure_signals_loaded").html("no");
-              $("#secure_signals_value").html("undefined");
-            }
-          } catch (e) {
-            console.log("Secure signals not yet available", e);
-            $("#secure_signals_loaded").html("no");
-            $("#secure_signals_value").html("undefined");
-          }
-        }
-        
-        // No "token ready" event on server-side; poll so we update the UI after the SDK writes to localStorage.
-        [1000, 2000, 3000].forEach((ms) => setTimeout(updateSecureSignals, ms));
-        
-        $('#logout').click(() => {
-          if (window.googletag && window.googletag.secureSignalProviders) {
-            window.googletag.secureSignalProviders.clearAllCache();
-          }
-          localStorage.removeItem(secureSignalsStorageKey);
-          window.location.href = '/logout';
-        });
-
-        $('#try_another').click(() => {
-          if (window.googletag && window.googletag.secureSignalProviders) {
-            window.googletag.secureSignalProviders.clearAllCache();
-          }
-          localStorage.removeItem(secureSignalsStorageKey);
-          window.location.href = '/logout';
-        });
-      });
-    </script>
   </head>
   <body>
     <div class="page-wrapper">
@@ -292,5 +230,66 @@
         </div>
       </aside>
     </div>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script type="text/javascript">
+      // For server-side integrations, the token callback must be defined before the SDKs that use it (e.g. Secure Signals) load.
+      const getUid2AdvertisingToken = async () => {
+        const response = await fetch('/getFreshToken');
+        if (!response.ok) return undefined;
+        const result = await response.json();
+        return result && result.advertising_token;
+      };
+      window.getUid2AdvertisingToken = getUid2AdvertisingToken;
+    </script>
+    <script src="<%- secureSignalsSdkUrl %>"></script>
+    <script type="text/javascript">
+      if (window.__uid2SecureSignalProvider) {
+        window.__uid2SecureSignalProvider.registerSecureSignalProvider();
+      }
+    </script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+    <script>
+      $(document).ready(() => {
+        const secureSignalsStorageKey = '<%- secureSignalsStorageKey %>';
+        
+        function updateSecureSignals() {
+          try {
+            const secureSignalsStorage = localStorage[secureSignalsStorageKey];
+            const secureSignalsStorageJson = secureSignalsStorage && JSON.parse(secureSignalsStorage);
+            
+            if (secureSignalsStorageJson && secureSignalsStorageJson[1]) {
+              $("#secure_signals_loaded").html("yes");
+              $("#secure_signals_value").html(JSON.stringify(secureSignalsStorageJson, null, 2));
+            } else {
+              $("#secure_signals_loaded").html("no");
+              $("#secure_signals_value").html("undefined");
+            }
+          } catch (e) {
+            console.log("Secure signals not yet available", e);
+            $("#secure_signals_loaded").html("no");
+            $("#secure_signals_value").html("undefined");
+          }
+        }
+        
+        // No "token ready" event on server-side; poll so we update the UI after the SDK writes to localStorage.
+        [1000, 2000, 3000].forEach((ms) => setTimeout(updateSecureSignals, ms));
+        
+        $('#logout').click(() => {
+          if (window.googletag && window.googletag.secureSignalProviders) {
+            window.googletag.secureSignalProviders.clearAllCache();
+          }
+          localStorage.removeItem(secureSignalsStorageKey);
+          window.location.href = '/logout';
+        });
+
+        $('#try_another').click(() => {
+          if (window.googletag && window.googletag.secureSignalProviders) {
+            window.googletag.secureSignalProviders.clearAllCache();
+          }
+          localStorage.removeItem(secureSignalsStorageKey);
+          window.location.href = '/logout';
+        });
+      });
+    </script>
   </body>
 </html>

--- a/web-integrations/google-secure-signals/server-side/views/index.html
+++ b/web-integrations/google-secure-signals/server-side/views/index.html
@@ -7,24 +7,22 @@
     <link rel="stylesheet" type="text/css" href="/stylesheets/style.css" />
     <link rel="shortcut icon" href="/images/favicon.png" />
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script async src="<%- secureSignalsSdkUrl %>"></script>
-    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
-
     <script type="text/javascript">
       const getUid2AdvertisingToken = async () => {
         const response = await fetch('/getFreshToken');
+        if (!response.ok) return undefined;
         const result = await response.json();
-        console.log(result);
-        return result.advertising_token;
+        return result && result.advertising_token;
       };
-
       window.getUid2AdvertisingToken = getUid2AdvertisingToken;
-
-      // If uid2SecureSignalProvider is initialized before getUid2AdvertisingToken is assigned, call registerSecureSignalProvider
+    </script>
+    <script src="<%- secureSignalsSdkUrl %>"></script>
+    <script type="text/javascript">
       if (window.__uid2SecureSignalProvider) {
         window.__uid2SecureSignalProvider.registerSecureSignalProvider();
       }
     </script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
     <script>
       $(document).ready(() => {
         const secureSignalsStorageKey = '<%- secureSignalsStorageKey %>';
@@ -48,8 +46,7 @@
           }
         }
         
-        // Update Secure Signals display after SDK has time to load and fetch token
-        setTimeout(updateSecureSignals, 1000);
+        [1000, 2000, 3000].forEach((ms) => setTimeout(updateSecureSignals, ms));
         
         $('#logout').click(() => {
           if (window.googletag && window.googletag.secureSignalProviders) {
@@ -107,6 +104,7 @@
 
         <!-- UID2 Integration Status Section -->
         <h2><%- identityName %> Integration Status</h2>
+        <p class="section-summary"><strong>Note:</strong> This is a test-only integration environment—it does not collect data or generate production-level tokens.</p>
 
         <table id="uid_state">
           <tr>

--- a/web-integrations/google-secure-signals/server-side/views/index.html
+++ b/web-integrations/google-secure-signals/server-side/views/index.html
@@ -6,6 +6,67 @@
     <link rel="stylesheet" type="text/css" href="/stylesheets/app.css" />
     <link rel="stylesheet" type="text/css" href="/stylesheets/style.css" />
     <link rel="shortcut icon" href="/images/favicon.png" />
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script type="text/javascript">
+      // For server-side integrations, the token callback must be defined before the SDKs that use it (e.g. Secure Signals) load.
+      const getUid2AdvertisingToken = async () => {
+        const response = await fetch('/getFreshToken');
+        if (!response.ok) return undefined;
+        const result = await response.json();
+        return result && result.advertising_token;
+      };
+      window.getUid2AdvertisingToken = getUid2AdvertisingToken;
+    </script>
+    <script src="<%- secureSignalsSdkUrl %>"></script>
+    <script type="text/javascript">
+      if (window.__uid2SecureSignalProvider) {
+        window.__uid2SecureSignalProvider.registerSecureSignalProvider();
+      }
+    </script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+    <script>
+      $(document).ready(() => {
+        const secureSignalsStorageKey = '<%- secureSignalsStorageKey %>';
+        
+        function updateSecureSignals() {
+          try {
+            const secureSignalsStorage = localStorage[secureSignalsStorageKey];
+            const secureSignalsStorageJson = secureSignalsStorage && JSON.parse(secureSignalsStorage);
+            
+            if (secureSignalsStorageJson && secureSignalsStorageJson[1]) {
+              $("#secure_signals_loaded").html("yes");
+              $("#secure_signals_value").html(JSON.stringify(secureSignalsStorageJson, null, 2));
+            } else {
+              $("#secure_signals_loaded").html("no");
+              $("#secure_signals_value").html("undefined");
+            }
+          } catch (e) {
+            console.log("Secure signals not yet available", e);
+            $("#secure_signals_loaded").html("no");
+            $("#secure_signals_value").html("undefined");
+          }
+        }
+        
+        // No "token ready" event on server-side; poll so we update the UI after the SDK writes to localStorage.
+        [1000, 2000, 3000].forEach((ms) => setTimeout(updateSecureSignals, ms));
+        
+        $('#logout').click(() => {
+          if (window.googletag && window.googletag.secureSignalProviders) {
+            window.googletag.secureSignalProviders.clearAllCache();
+          }
+          localStorage.removeItem(secureSignalsStorageKey);
+          window.location.href = '/logout';
+        });
+
+        $('#try_another').click(() => {
+          if (window.googletag && window.googletag.secureSignalProviders) {
+            window.googletag.secureSignalProviders.clearAllCache();
+          }
+          localStorage.removeItem(secureSignalsStorageKey);
+          window.location.href = '/logout';
+        });
+      });
+    </script>
   </head>
   <body>
     <div class="page-wrapper">
@@ -230,66 +291,5 @@
         </div>
       </aside>
     </div>
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script type="text/javascript">
-      // For server-side integrations, the token callback must be defined before the SDKs that use it (e.g. Secure Signals) load.
-      const getUid2AdvertisingToken = async () => {
-        const response = await fetch('/getFreshToken');
-        if (!response.ok) return undefined;
-        const result = await response.json();
-        return result && result.advertising_token;
-      };
-      window.getUid2AdvertisingToken = getUid2AdvertisingToken;
-    </script>
-    <script src="<%- secureSignalsSdkUrl %>"></script>
-    <script type="text/javascript">
-      if (window.__uid2SecureSignalProvider) {
-        window.__uid2SecureSignalProvider.registerSecureSignalProvider();
-      }
-    </script>
-    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
-    <script>
-      $(document).ready(() => {
-        const secureSignalsStorageKey = '<%- secureSignalsStorageKey %>';
-        
-        function updateSecureSignals() {
-          try {
-            const secureSignalsStorage = localStorage[secureSignalsStorageKey];
-            const secureSignalsStorageJson = secureSignalsStorage && JSON.parse(secureSignalsStorage);
-            
-            if (secureSignalsStorageJson && secureSignalsStorageJson[1]) {
-              $("#secure_signals_loaded").html("yes");
-              $("#secure_signals_value").html(JSON.stringify(secureSignalsStorageJson, null, 2));
-            } else {
-              $("#secure_signals_loaded").html("no");
-              $("#secure_signals_value").html("undefined");
-            }
-          } catch (e) {
-            console.log("Secure signals not yet available", e);
-            $("#secure_signals_loaded").html("no");
-            $("#secure_signals_value").html("undefined");
-          }
-        }
-        
-        // No "token ready" event on server-side; poll so we update the UI after the SDK writes to localStorage.
-        [1000, 2000, 3000].forEach((ms) => setTimeout(updateSecureSignals, ms));
-        
-        $('#logout').click(() => {
-          if (window.googletag && window.googletag.secureSignalProviders) {
-            window.googletag.secureSignalProviders.clearAllCache();
-          }
-          localStorage.removeItem(secureSignalsStorageKey);
-          window.location.href = '/logout';
-        });
-
-        $('#try_another').click(() => {
-          if (window.googletag && window.googletag.secureSignalProviders) {
-            window.googletag.secureSignalProviders.clearAllCache();
-          }
-          localStorage.removeItem(secureSignalsStorageKey);
-          window.location.href = '/logout';
-        });
-      });
-    </script>
   </body>
 </html>

--- a/web-integrations/google-secure-signals/server-side/views/index.html
+++ b/web-integrations/google-secure-signals/server-side/views/index.html
@@ -8,6 +8,7 @@
     <link rel="shortcut icon" href="/images/favicon.png" />
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script type="text/javascript">
+      // Define callback before Secure Signals SDK loads so the SDK can find it when it runs.
       const getUid2AdvertisingToken = async () => {
         const response = await fetch('/getFreshToken');
         if (!response.ok) return undefined;
@@ -16,6 +17,7 @@
       };
       window.getUid2AdvertisingToken = getUid2AdvertisingToken;
     </script>
+    <!-- Load Secure Signals SDK after callback (sync, same order as client-side). -->
     <script src="<%- secureSignalsSdkUrl %>"></script>
     <script type="text/javascript">
       if (window.__uid2SecureSignalProvider) {
@@ -46,6 +48,7 @@
           }
         }
         
+        // No "token ready" event on server-side; poll so we update the UI after the SDK writes to localStorage.
         [1000, 2000, 3000].forEach((ms) => setTimeout(updateSecureSignals, ms));
         
         $('#logout').click(() => {


### PR DESCRIPTION
Added refresh/retry logic so the UI stays in sync with the server:
- Moved the secure signals script from header to after token callback to prevent sync (consistent with client-side)
- Lengthened/added timeouts used to check storage
- Added an additional check to client server to check if token exists on refresh and retry if need (consistent with client-side) & updated one of the env variables to include a default just incase