### PR TITLE
Update server side gss detection to check for second index in storage

### DIFF
--- a/web-integrations/google-secure-signals/server-side/views/index.html
+++ b/web-integrations/google-secure-signals/server-side/views/index.html
@@ -33,7 +33,10 @@
             const secureSignalsStorage = localStorage[secureSignalsStorageKey];
             const secureSignalsStorageJson = secureSignalsStorage && JSON.parse(secureSignalsStorage);
             
-            if (secureSignalsStorageJson && secureSignalsStorageJson[1]) {
+            // Check index [2] (expiry timestamp) rather than [1] (token).
+            // Newer GPT versions use a 10-element format where index [1] is null
+            // and the token is no longer stored in plaintext in the cache.
+            if (secureSignalsStorageJson && secureSignalsStorageJson[2]) {
               $("#secure_signals_loaded").html("yes");
               $("#secure_signals_value").html(JSON.stringify(secureSignalsStorageJson, null, 2));
             } else {


### PR DESCRIPTION
GPT changed their 3-element format:`["uidapi.com", "A4AAAA...token...", 1773706288043]` to a newer 10-element format:`["uidapi.com", null, 1773701406276, null, null, null, null,`. Server-side was using the new format but referencing the older index which caused the UI detection to always display as null/no