### PR TITLE
UID2-6844: fix npm vulnerabilities - node-forge, path-to-regexp, picomatch, flatted

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -3,7 +3,7 @@ on: [pull_request, push, workflow_dispatch]
 
 jobs:
   build:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-build-and-test.yaml@v2
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-build-and-test.yaml@v3
     secrets: inherit
     with:
       vulnerability_scan_only: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -556,9 +556,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "dev": true,
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     "tsx": "^4.19.1"
   },
   "overrides": {
-    "qs": "6.14.1"
+    "qs": "6.14.1",
+    "path-to-regexp@0": "0.1.13",
+    "node-forge": "^1.4.0",
+    "picomatch": "^2.3.2",
+    "flatted": "^3.4.2"
   },
   "resolutions": {
     "qs": "6.14.1"

--- a/web-integrations/google-secure-signals/client-server/package-lock.json
+++ b/web-integrations/google-secure-signals/client-server/package-lock.json
@@ -1752,9 +1752,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3021,9 +3021,10 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -3040,10 +3041,11 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },

--- a/web-integrations/google-secure-signals/client-server/package.json
+++ b/web-integrations/google-secure-signals/client-server/package.json
@@ -22,7 +22,10 @@
     "form-data": "^4.0.4",
     "minimatch": "^10.2.3",
     "qs": "6.14.1",
-    "flatted": "^3.4.0"
+    "flatted": "^3.4.2",
+    "path-to-regexp@0": "0.1.13",
+    "node-forge": "^1.4.0",
+    "picomatch": "^2.3.2"
   },
   "devDependencies": {
     "eslint": "^7.29.0",

--- a/web-integrations/google-secure-signals/react-client-side/package-lock.json
+++ b/web-integrations/google-secure-signals/react-client-side/package-lock.json
@@ -7675,9 +7675,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -10900,9 +10900,10 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
-      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -11350,9 +11351,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -11373,9 +11375,10 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -15290,23 +15293,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {

--- a/web-integrations/google-secure-signals/react-client-side/package.json
+++ b/web-integrations/google-secure-signals/react-client-side/package.json
@@ -28,13 +28,15 @@
     "minimatch": "^10.2.3",
     "rollup": "^2.80.0",
     "serialize-javascript": "^7.0.3",
-    "node-forge": "^1.3.2",
+    "node-forge": "^1.4.0",
     "postcss": "^8.4.31",
     "webpack-dev-server": "^5.2.1",
     "qs": "6.14.1",
     "svgo@2": "2.8.1",
     "underscore": "^1.13.8",
-    "flatted": "^3.4.0"
+    "flatted": "^3.4.2",
+    "path-to-regexp@0": "0.1.13",
+    "picomatch": "^2.3.2"
   },
   "scripts": {
     "start": "node server.js",

--- a/web-integrations/google-secure-signals/server-side/package-lock.json
+++ b/web-integrations/google-secure-signals/server-side/package-lock.json
@@ -15,7 +15,7 @@
         "express": "^4.21.2",
         "minimist": "^1.2.6",
         "nocache": "^3.0.1",
-        "path-to-regexp": "^8.2.0"
+        "path-to-regexp": "^8.4.0"
       },
       "devDependencies": {
         "eslint": "^7.29.0",
@@ -1737,9 +1737,10 @@
       }
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1864,9 +1865,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3161,9 +3162,10 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -3184,10 +3186,11 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },

--- a/web-integrations/google-secure-signals/server-side/package.json
+++ b/web-integrations/google-secure-signals/server-side/package.json
@@ -18,13 +18,16 @@
     "express": "^4.21.2",
     "minimist": "^1.2.6",
     "nocache": "^3.0.1",
-    "path-to-regexp": "^8.2.0"
+    "path-to-regexp": "^8.4.0"
   },
   "overrides": {
     "form-data": "^4.0.4",
     "minimatch": "^10.2.3",
     "qs": "6.14.1",
-    "flatted": "^3.4.0"
+    "flatted": "^3.4.2",
+    "path-to-regexp@0": "0.1.13",
+    "node-forge": "^1.4.0",
+    "picomatch": "^2.3.2"
   },
   "devDependencies": {
     "eslint": "^7.29.0",

--- a/web-integrations/javascript-sdk/client-server/package-lock.json
+++ b/web-integrations/javascript-sdk/client-server/package-lock.json
@@ -14,7 +14,7 @@
         "dotenv": "^17.2.3",
         "ejs": "^3.1.7",
         "express": "^4.21.2",
-        "path-to-regexp": "^8.2.0"
+        "path-to-regexp": "^8.4.0"
       },
       "devDependencies": {
         "eslint": "^7.29.0",
@@ -1725,9 +1725,10 @@
       }
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1852,9 +1853,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3123,9 +3124,10 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -3146,10 +3148,11 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },

--- a/web-integrations/javascript-sdk/client-server/package.json
+++ b/web-integrations/javascript-sdk/client-server/package.json
@@ -17,7 +17,7 @@
     "dotenv": "^17.2.3",
     "ejs": "^3.1.7",
     "express": "^4.21.2",
-    "path-to-regexp": "^8.2.0"
+    "path-to-regexp": "^8.4.0"
   },
   "devDependencies": {
     "eslint": "^7.29.0",
@@ -29,7 +29,10 @@
     "jws": "4.0.1",
     "minimatch": "^10.2.3",
     "qs": "6.14.1",
-    "flatted": "^3.4.0"
+    "flatted": "^3.4.2",
+    "path-to-regexp@0": "0.1.13",
+    "node-forge": "^1.4.0",
+    "picomatch": "^2.3.2"
   },
   "resolutions": {
     "jws": "4.0.1",

--- a/web-integrations/javascript-sdk/react-client-side/package-lock.json
+++ b/web-integrations/javascript-sdk/react-client-side/package-lock.json
@@ -7647,9 +7647,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -10872,9 +10872,10 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
-      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -11322,9 +11323,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -11345,9 +11347,10 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -15258,23 +15261,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {

--- a/web-integrations/javascript-sdk/react-client-side/package.json
+++ b/web-integrations/javascript-sdk/react-client-side/package.json
@@ -28,13 +28,15 @@
     "minimatch": "^10.2.3",
     "rollup": "^2.80.0",
     "serialize-javascript": "^7.0.3",
-    "node-forge": "^1.3.2",
+    "node-forge": "^1.4.0",
     "postcss": "^8.4.31",
     "webpack-dev-server": "^5.2.1",
     "qs": "6.14.1",
     "svgo@2": "2.8.1",
     "underscore": "^1.13.8",
-    "flatted": "^3.4.0"
+    "flatted": "^3.4.2",
+    "path-to-regexp@0": "0.1.13",
+    "picomatch": "^2.3.2"
   },
   "scripts": {
     "start": "node server.js",

--- a/web-integrations/prebid-integrations/client-server/package-lock.json
+++ b/web-integrations/prebid-integrations/client-server/package-lock.json
@@ -715,9 +715,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"

--- a/web-integrations/prebid-integrations/client-server/package.json
+++ b/web-integrations/prebid-integrations/client-server/package.json
@@ -23,6 +23,7 @@
     "path-to-regexp@0": "0.1.13",
     "node-forge": "^1.4.0",
     "picomatch": "^2.3.2",
-    "flatted": "^3.4.2"
+    "flatted": "^3.4.2",
+    "path-to-regexp": "^8.4.0"
   }
 }

--- a/web-integrations/prebid-integrations/client-server/package.json
+++ b/web-integrations/prebid-integrations/client-server/package.json
@@ -19,6 +19,10 @@
   "overrides": {
     "body-parser": "^2.2.1",
     "minimatch": "^10.2.3",
-    "qs": "6.14.1"
+    "qs": "6.14.1",
+    "path-to-regexp@0": "0.1.13",
+    "node-forge": "^1.4.0",
+    "picomatch": "^2.3.2",
+    "flatted": "^3.4.2"
   }
 }

--- a/web-integrations/server-side/package-lock.json
+++ b/web-integrations/server-side/package-lock.json
@@ -15,7 +15,7 @@
         "ejs": "^3.1.7",
         "express": "^4.21.2",
         "nocache": "^3.0.1",
-        "path-to-regexp": "^8.2.0"
+        "path-to-regexp": "^8.4.0"
       },
       "devDependencies": {
         "eslint": "^7.29.0",
@@ -1464,9 +1464,10 @@
       }
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1586,9 +1587,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2684,11 +2685,13 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {
@@ -2701,10 +2704,11 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },

--- a/web-integrations/server-side/package.json
+++ b/web-integrations/server-side/package.json
@@ -18,7 +18,7 @@
     "ejs": "^3.1.7",
     "express": "^4.21.2",
     "nocache": "^3.0.1",
-    "path-to-regexp": "^8.2.0"
+    "path-to-regexp": "^8.4.0"
   },
   "devDependencies": {
     "eslint": "^7.29.0",
@@ -29,7 +29,10 @@
   "overrides": {
     "minimatch": "^10.2.3",
     "qs": "6.14.1",
-    "flatted": "^3.4.0"
+    "flatted": "^3.4.2",
+    "path-to-regexp@0": "0.1.13",
+    "node-forge": "^1.4.0",
+    "picomatch": "^2.3.2"
   },
   "resolutions": {
     "qs": "6.14.1"


### PR DESCRIPTION
## Summary

Fixes multiple HIGH severity npm vulnerabilities across root and all web-integration sub-packages.

Note: CVE-2026-4926 (path-to-regexp 8.x) was also fixed in the server-side sub-packages here, and was previously fixed in uid2-web-integrations ([UID2-6838](https://thetradedesk.atlassian.net/browse/UID2-6838)).

| Package | CVE(s) | Severity | Fix |
|---------|--------|----------|-----|
| node-forge | CVE-2026-33891/33894/33895/33896 | HIGH | 1.3.2 → 1.4.0 (override) |
| path-to-regexp 0.1.x | CVE-2026-4867 | HIGH | 0.1.12 → 0.1.13 (override) |
| path-to-regexp 8.x | CVE-2026-4926 | HIGH | 8.2/8.3 → 8.4.0 (direct dep bump in server-side packages) |
| picomatch | CVE-2026-33671 | HIGH | 2.3.1 → 2.3.2 (override) |
| flatted | CVE-2026-33228 | HIGH | 3.4.1 → 3.4.2 (override) |

**Jira:** [UID2-6844](https://thetradedesk.atlassian.net/browse/UID2-6844)

## Test plan
- [ ] CI vulnerability scan passes
- [ ] Build passes for all sub-packages