### PR TITLE
UID2-6913: Pin third-party GitHub Action refs to commit SHAs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,7 +33,7 @@ jobs:
             type=sha,prefix=server_only-,format=short
             type=raw,prefix=server_only-,value=latest
       - name: Build and push Docker server_only image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: publisher/server_only
           push: true
@@ -62,7 +62,7 @@ jobs:
             type=sha,prefix=standard-,format=short
             type=raw,prefix=standard-,value=latest
       - name: Build and push Docker standard image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: publisher/standard
           push: true
@@ -91,7 +91,7 @@ jobs:
             type=sha,prefix=reverse-proxy-,format=short
             type=raw,prefix=reverse-proxy-,value=latest
       - name: Build and push Docker reverse-proxy image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: tools/reverse-proxy
           file: Dockerfile


### PR DESCRIPTION
## Summary
Pin third-party (non-GitHub-owned) action references to full-length commit SHAs to mitigate supply-chain attacks from mutable tags.

Only external actions are pinned in this PR (e.g. `docker/*`, `aws-actions/*`, `softprops/*`, etc.). GitHub-owned actions (`actions/*`) are not included in this change.

## Verification
Each SHA can be verified with:
```
git ls-remote https://github.com/<owner>/<repo> <tag>
```

## Test plan
- [ ] Verify CI passes with pinned refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)