### PR TITLE
UID2-6799 Use 'ci-auto-merge' environment

### DIFF
--- a/.github/workflows/release-all-docker-images.yaml
+++ b/.github/workflows/release-all-docker-images.yaml
@@ -18,6 +18,7 @@ jobs:
     with:
       release_type: ${{ inputs.release_type }}
       working_dir: .
+      merge_environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     secrets: inherit
     
   publishReverseProxyImage:


### PR DESCRIPTION
## Summary
Pass `merge_environment: 'ci-auto-merge'` on protected branches so the release workflow uses the UID2SourceAdmin PAT to bypass the PR review ruleset when auto-merging the version bump PR.