### PR TITLE
UID2-6742: upgrade Node.js 20 actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -33,7 +33,7 @@ jobs:
             type=sha,prefix=server_only-,format=short
             type=raw,prefix=server_only-,value=latest
       - name: Build and push Docker server_only image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: publisher/server_only
           push: true
@@ -46,7 +46,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -62,7 +62,7 @@ jobs:
             type=sha,prefix=standard-,format=short
             type=raw,prefix=standard-,value=latest
       - name: Build and push Docker standard image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: publisher/standard
           push: true
@@ -75,7 +75,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
@@ -91,7 +91,7 @@ jobs:
             type=sha,prefix=reverse-proxy-,format=short
             type=raw,prefix=reverse-proxy-,value=latest
       - name: Build and push Docker reverse-proxy image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: tools/reverse-proxy
           file: Dockerfile


### PR DESCRIPTION
## Summary
- \`actions/checkout@v4\` → \`@de0fac2e\` (v6.0.2) (×3)
- \`docker/build-push-action@v5\` → \`@bcafcacb\` (v7.1.0) (×3)

Node.js 20 is deprecated on GitHub Actions runners; forced cutover **June 2, 2026**.

## Jira
https://thetradedesk.atlassian.net/browse/UID2-6742

🤖 Generated with [Claude Code](https://claude.com/claude-code)