### PR TITLE
UID2-7411: Remediate HIGH/CRITICAL vulns in reverse-proxy image

### DIFF
--- a/tools/reverse-proxy/Dockerfile
+++ b/tools/reverse-proxy/Dockerfile
@@ -1,5 +1,8 @@
 FROM nginx:alpine
 
+# Upgrade base Alpine packages to latest security builds (openssl/libssl3/libcrypto3, musl, zlib, libxml2, libexpat, nghttp2)
+RUN apk upgrade --no-cache
+
 # Install wget for healthcheck, gettext for envsubst, and openssl for fallback cert generation
 RUN apk add --no-cache wget gettext openssl
 


### PR DESCRIPTION
## Summary

Part of UID2-7411 — remediate HIGH/CRITICAL vulnerabilities in docker-path images so the Trivy failure floor in `IABTechLab/uid2-shared-actions#246` can flip from `CRITICAL` to `CRITICAL,HIGH`.

This PR covers `tools/reverse-proxy/Dockerfile` (`FROM nginx:alpine`).

## Change

Added `RUN apk upgrade --no-cache` immediately after the `FROM` line, before the existing `apk add`. This pulls the latest `-rN` Alpine security builds at build time (openssl/libssl3/libcrypto3, musl, zlib, libxml2, libexpat, nghttp2, etc.).

No `.trivyignore` suppression was required — the upgrade alone brings the image to zero HIGH/CRITICAL findings.

## Verification

```
docker build --platform linux/amd64 -f tools/reverse-proxy/Dockerfile -t uid-reverse-proxy-test tools/reverse-proxy
trivy image --platform linux/amd64 --severity CRITICAL,HIGH --scanners vuln uid-reverse-proxy-test
```

Rescan result (Trivy 0.72.0):

```
Report Summary

┌────────────────────────────────────────┬────────┬─────────────────┐
│                 Target                 │  Type  │ Vulnerabilities │
├────────────────────────────────────────┼────────┼─────────────────┤
│ uid-reverse-proxy-test (alpine 3.23.5) │ alpine │        0        │
└────────────────────────────────────────┴────────┴─────────────────┘
```

Total: 0 (CRITICAL: 0, HIGH: 0) — build is clean at `CRITICAL,HIGH`.