### PR TITLE
UID2-7491: bump websocket-driver to 0.7.5 (CVE-2026-54466)

### DIFF
--- a/web-integrations/google-secure-signals/react-client-side/package-lock.json
+++ b/web-integrations/google-secure-signals/react-client-side/package-lock.json
@@ -16308,9 +16308,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",

--- a/web-integrations/google-secure-signals/react-client-side/package.json
+++ b/web-integrations/google-secure-signals/react-client-side/package.json
@@ -41,7 +41,8 @@
     "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
     "fast-uri": ">=3.1.2",
     "shell-quote": "^1.8.4",
-    "ws": ">=7.5.11"
+    "ws": ">=7.5.11",
+    "websocket-driver": "^0.7.5"
   },
   "scripts": {
     "start": "node server.js",

--- a/web-integrations/javascript-sdk/react-client-side/package-lock.json
+++ b/web-integrations/javascript-sdk/react-client-side/package-lock.json
@@ -16284,9 +16284,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",

--- a/web-integrations/javascript-sdk/react-client-side/package.json
+++ b/web-integrations/javascript-sdk/react-client-side/package.json
@@ -41,7 +41,8 @@
     "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
     "fast-uri": ">=3.1.2",
     "shell-quote": "^1.8.4",
-    "ws": ">=7.5.11"
+    "ws": ">=7.5.11",
+    "websocket-driver": "^0.7.5"
   },
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
## Summary

Resolves **CVE-2026-54466** (CRITICAL) — `websocket-driver` message corruption via abuse of protocol length headers.

Upgrades `websocket-driver` **0.7.4 → 0.7.5** in the two affected React example projects by adding an npm `overrides` entry (`"websocket-driver": "^0.7.5"`) and regenerating `package-lock.json`:

- `web-integrations/google-secure-signals/react-client-side`
- `web-integrations/javascript-sdk/react-client-side`

## Impact assessment

`websocket-driver` is pulled in only via the dev dependency chain (`react-scripts` → `webpack-dev-server` → `sockjs`/`faye-websocket` → `websocket-driver`). `webpack-dev-server` is the local hot-reload dev server used during `npm start`; it does not run in production. The examples are served as static builds, so no `websocket-driver` WebSocket server runs in the deployed artifact and the attack vector is not reachable in production.

Because a fixed version is available and this is a trivial patch bump of a leaf transitive dependency, a permanent override was preferred over a time-limited `.trivyignore` suppression (which would re-fire this CRITICAL alarm on expiry). This matches the repo's existing convention of pinning transitive security fixes in the `overrides` block (`ws`, `shell-quote`, `minimatch`, etc.).

Jira: https://thetradedesk.atlassian.net/browse/UID2-7491

🤖 Generated with [Claude Code](https://claude.com/claude-code)