### PR TITLE
UID2-7554/7555: bump fast-uri npm override to ^3.1.4; suppress svgo GHSA-2p49 (react-scripts residual)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -11,3 +11,12 @@ CVE-2026-1615 exp:2026-09-16
 # zlib contrib/untgz demo utility buffer overflow - not exploitable; Alpine does not ship the untgz binary.
 # See: UID2-6704
 CVE-2026-22184 exp:2026-09-09
+
+# GHSA-2p49-hgcm-8545 (HIGH) - svgo removeScripts plugin leaves some executable scripts intact.
+# svgo is build-time-only tooling here: it optimizes the examples' own (trusted) SVG assets at
+# build time and is never run against untrusted input, so it is not reachable at runtime. The
+# app-level svgo (3.x) and postcss-svgo (2.x) could be bumped, but a third copy is svgo 1.3.2
+# bundled inside react-scripts@5's @svgr/webpack@5.5.0, which has NO in-major fix (fixed only in
+# 2.8.3+); forcing it across the major breaks the create-react-app build. Suppressing until
+# react-scripts is upgraded/removed. See: UID2-7555 (fix precedent UID2-6698)
+GHSA-2p49-hgcm-8545 exp:2026-08-23

--- a/web-integrations/google-secure-signals/react-client-side/package-lock.json
+++ b/web-integrations/google-secure-signals/react-client-side/package-lock.json
@@ -7490,9 +7490,9 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -7502,7 +7502,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -15308,6 +15309,23 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {

--- a/web-integrations/google-secure-signals/react-client-side/package.json
+++ b/web-integrations/google-secure-signals/react-client-side/package.json
@@ -39,7 +39,7 @@
     "picomatch": "^2.3.2",
     "lodash": "^4.18.0",
     "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
-    "fast-uri": ">=3.1.2",
+    "fast-uri": "^3.1.4",
     "shell-quote": "1.9.0",
     "ws": ">=7.5.11",
     "websocket-driver": "^0.7.5",

--- a/web-integrations/javascript-sdk/react-client-side/package-lock.json
+++ b/web-integrations/javascript-sdk/react-client-side/package-lock.json
@@ -7462,9 +7462,9 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -7474,7 +7474,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -15276,6 +15277,23 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {

--- a/web-integrations/javascript-sdk/react-client-side/package.json
+++ b/web-integrations/javascript-sdk/react-client-side/package.json
@@ -39,7 +39,7 @@
     "picomatch": "^2.3.2",
     "lodash": "^4.18.0",
     "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
-    "fast-uri": ">=3.1.2",
+    "fast-uri": "^3.1.4",
     "shell-quote": "1.9.0",
     "ws": ">=7.5.11",
     "websocket-driver": "^0.7.5",


### PR DESCRIPTION
## Vulnerability fix — npm (fast-uri) + svgo suppression

Affects the two `web-integrations/**/react-client-side` sub-projects flagged by `trivy fs`.

**fast-uri — CVE-2026-13676, CVE-2026-16221 (HIGH)** — real fix: bump the existing override `fast-uri >=3.1.2` → `^3.1.4` (resolves 3.1.4, stays on 3.x). Lockfiles regenerated.

**svgo — GHSA-2p49-hgcm-8545 (HIGH)** — suppressed in `.trivyignore` (exp 2026-08-23). Rationale: svgo is build-time-only SVG optimization of our own trusted assets (not reachable at runtime). The app-level svgo already resolves to fixed 3.3.4, but a residual copy is svgo 1.3.2 bundled inside react-scripts@5’s `@svgr/webpack@5.5.0`, which has **no in-major fix** (fixed only in 2.8.3+); forcing it across the major breaks the create-react-app build (verified locally). Suppress until react-scripts is upgraded/removed.

Tickets: UID2-7554 (fast-uri), UID2-7555 (svgo).